### PR TITLE
Allow test suite to run with multiple threads

### DIFF
--- a/courier.cabal
+++ b/courier.cabal
@@ -32,6 +32,7 @@ extra-source-files:  changes.md
                      tests/TestTCP.hs
                      tests/TestTransports.hs
                      tests/TestUDP.hs
+                     tests/TestUtils.hs
 
 homepage:          http://github.com/hargettp/courier
 license:             MIT

--- a/tests/TestTCP.hs
+++ b/tests/TestTCP.hs
@@ -6,6 +6,7 @@ import Network.Endpoints
 import Network.Transport.TCP
 
 import TestTransports
+import TestUtils
 
 -- external imports
 
@@ -22,36 +23,32 @@ import Test.Framework.Providers.HUnit
 _log :: String
 _log = "test.transport.tcp"
 
-address1 :: Address
-address1 = "localhost:20001"
-
-address2 :: Address
-address2 = "localhost:20002"
-
 tests :: [Test.Framework.Test]
 tests =
   [
     testCase "tcp-endpoints+transport" $ testEndpointTransport newTCPTransport,
-    testCase "tcp-bind-unbind" $ endpointBindUnbind _log newTCPTransport address1 address2,
-    testCase "tcp-send-receive" $ endpointSendReceive _log newTCPTransport address1 address2,
-    testCase "tcp-double-send-receive" $ endpointDoubleSendReceive _log newTCPTransport address1 address2,
-    testCase "tcp-send-receive-reply" $ endpointSendReceiveReply _log newTCPTransport address1 address2,
-    testCase "tcp-multiple-send-receive-reply" $ endpointMultipleSendReceiveReply _log newTCPTransport address1 address2,
-    testCase "tcp-local-send-receive-reply" $ endpointLocalSendReceiveReply _log newTCPTransport address1 address2,
+    testCase "tcp-bind-unbind" $ endpointBindUnbind _log newTCPTransport newTCPAddress,
+    testCase "tcp-send-receive" $ endpointSendReceive _log newTCPTransport newTCPAddress,
+    testCase "tcp-double-send-receive" $ endpointDoubleSendReceive _log newTCPTransport newTCPAddress,
+    testCase "tcp-send-receive-reply" $ endpointSendReceiveReply _log newTCPTransport newTCPAddress,
+    testCase "tcp-multiple-send-receive-reply" $ endpointMultipleSendReceiveReply _log newTCPTransport newTCPAddress,
+    testCase "tcp-local-send-receive-reply" $ endpointLocalSendReceiveReply _log newTCPTransport newTCPAddress,
 
     testCase "tcp6-endpoints+transport" $ whenIPv6 $ testEndpointTransport newTCPTransport6,
-    testCase "tcp6-bind-unbind" $ whenIPv6 $ endpointBindUnbind _log newTCPTransport6 address1 address2,
-    testCase "tcp6-send-receive" $ whenIPv6 $ endpointSendReceive _log newTCPTransport6 address1 address2,
-    testCase "tcp6-double-send-receive" $ whenIPv6 $ endpointDoubleSendReceive _log newTCPTransport6 address1 address2,
-    testCase "tcp6-send-receive-reply" $ whenIPv6 $ endpointSendReceiveReply _log newTCPTransport6 address1 address2,
-    testCase "tcp6-multiple-send-receive-reply" $ whenIPv6 $ endpointMultipleSendReceiveReply _log newTCPTransport6 address1 address2,
-    testCase "tcp6-local-send-receive-reply" $ whenIPv6 $ endpointLocalSendReceiveReply _log newTCPTransport6 address1 address2
+    testCase "tcp6-bind-unbind" $ whenIPv6 $ endpointBindUnbind _log newTCPTransport6 newTCPAddress6,
+    testCase "tcp6-send-receive" $ whenIPv6 $ endpointSendReceive _log newTCPTransport6 newTCPAddress6,
+    testCase "tcp6-double-send-receive" $ whenIPv6 $ endpointDoubleSendReceive _log newTCPTransport6 newTCPAddress6,
+    testCase "tcp6-send-receive-reply" $ whenIPv6 $ endpointSendReceiveReply _log newTCPTransport6 newTCPAddress6,
+    testCase "tcp6-multiple-send-receive-reply" $ whenIPv6 $ endpointMultipleSendReceiveReply _log newTCPTransport6 newTCPAddress6,
+    testCase "tcp6-local-send-receive-reply" $ whenIPv6 $ endpointLocalSendReceiveReply _log newTCPTransport6 newTCPAddress6
   ]
 
 testEndpointTransport :: (Resolver -> IO Transport) -> Assertion
 testEndpointTransport transportFactory = do
   let name1 = "endpoint1"
       name2 = "endpoint2"
+  address1 <- newTCPAddress
+  address2 <- newTCPAddress
   let resolver = resolverFromList [(name1,address1),
                                (name2,address2)]
   bracket (transportFactory resolver)

--- a/tests/TestTransports.hs
+++ b/tests/TestTransports.hs
@@ -54,11 +54,13 @@ whenIPv6 assn = do
         _ -> assn
 
 {-
-Common tests--just supply the transport factory and 2 addresses
+Common tests--just supply the transport factory and an address generator
 -}
 
-endpointTransport :: String -> (Resolver -> IO Transport) -> Address -> Address -> Assertion
-endpointTransport _log newTransport address1 address2 = do
+endpointTransport :: String -> (Resolver -> IO Transport) -> IO Address -> Assertion
+endpointTransport _log newTransport newAddress = do
+  address1 <- newAddress
+  address2 <- newAddress
   let name1 = "endpoint1"
       name2 = "endpoint2"
   let resolver = resolverFromList [(name1,address1),
@@ -69,9 +71,11 @@ endpointTransport _log newTransport address1 address2 = do
             _ <- newEndpoint [transport]
             return ())
 
-endpointBindUnbind :: String -> (Resolver -> IO Transport) -> Address -> Address -> Assertion
-endpointBindUnbind _log newTransport address1 address2 = do
+endpointBindUnbind :: String -> (Resolver -> IO Transport) -> IO Address -> Assertion
+endpointBindUnbind _log newTransport newAddress = do
   infoM _log "Starting bind-unbind test"
+  address1 <- newAddress
+  address2 <- newAddress
   let name1 = "endpoint1"
       name2 = "endpoint2"
   let resolver = resolverFromList [(name1,address1),
@@ -87,9 +91,11 @@ endpointBindUnbind _log newTransport address1 address2 = do
               Right () -> assertBool "Unbind succeeded" True
             return ())
 
-endpointSendReceive :: String -> (Resolver -> IO Transport) -> Address -> Address -> Assertion
-endpointSendReceive _log newTransport address1 address2 = do
+endpointSendReceive :: String -> (Resolver -> IO Transport) -> IO Address -> Assertion
+endpointSendReceive _log newTransport newAddress = do
   infoM _log "Starting send-receive test"
+  address1 <- newAddress
+  address2 <- newAddress
   let name1 = "endpoint1"
       name2 = "endpoint2"
   let resolver = resolverFromList [(name1,address1),
@@ -108,9 +114,11 @@ endpointSendReceive _log newTransport address1 address2 = do
       return ()
   infoM _log "Finished send-receive test"
 
-endpointDoubleSendReceive :: String -> (Resolver -> IO Transport) -> Address -> Address -> Assertion
-endpointDoubleSendReceive _log newTransport address1 address2 = do
+endpointDoubleSendReceive :: String -> (Resolver -> IO Transport) -> IO Address -> Assertion
+endpointDoubleSendReceive _log newTransport newAddress = do
   infoM _log "Starting double-send-receive test"
+  address1 <- newAddress
+  address2 <- newAddress
   let name1 = "endpoint1"
       name2 = "endpoint2"
       name3 = "endpoint3"
@@ -138,9 +146,11 @@ endpointDoubleSendReceive _log newTransport address1 address2 = do
       return ()
   infoM _log "Finished double-send-receive test"
 
-endpointSendReceiveReply :: String -> (Resolver -> IO Transport) -> Address -> Address -> Assertion
-endpointSendReceiveReply _log newTransport address1 address2 = do
+endpointSendReceiveReply :: String -> (Resolver -> IO Transport) -> IO Address -> Assertion
+endpointSendReceiveReply _log newTransport newAddress = do
   infoM _log "Starting send-receive-reply test"
+  address1 <- newAddress
+  address2 <- newAddress
   let name1 = "endpoint1"
       name2 = "endpoint2"
   let resolver = resolverFromList [(name1,address1),
@@ -161,9 +171,10 @@ endpointSendReceiveReply _log newTransport address1 address2 = do
       return ()
   infoM _log "Finished send-receive-reply test"
 
-endpointLocalSendReceiveReply :: String -> (Resolver -> IO Transport) -> Address -> Address -> Assertion
-endpointLocalSendReceiveReply _log newTransport address1 _ = do
+endpointLocalSendReceiveReply :: String -> (Resolver -> IO Transport) -> IO Address -> Assertion
+endpointLocalSendReceiveReply _log newTransport newAddress = do
   infoM _log "Starting local-send-receive-reply test"
+  address1 <- newAddress
   let name1 = "endpoint1"
       name2 = "endpoint2"
   let resolver = resolverFromList [(name1,address1),
@@ -186,9 +197,11 @@ endpointLocalSendReceiveReply _log newTransport address1 _ = do
         return ())
   infoM _log "Finished local-send-receive-reply test"
 
-endpointMultipleSendReceiveReply :: String -> (Resolver -> IO Transport) -> Address -> Address -> Assertion
-endpointMultipleSendReceiveReply _log newTransport address1 address2 = do
+endpointMultipleSendReceiveReply :: String -> (Resolver -> IO Transport) -> IO Address -> Assertion
+endpointMultipleSendReceiveReply _log newTransport newAddress = do
   infoM _log "Starting multiple-send-receive-reply test"
+  address1 <- newAddress
+  address2 <- newAddress
   let name1 = "endpoint1"
       name2 = "endpoint2"
   let resolver = resolverFromList [(name1,address1),

--- a/tests/TestUDP.hs
+++ b/tests/TestUDP.hs
@@ -6,11 +6,11 @@ import Network.Endpoints
 import Network.Transport.UDP
 
 import TestTransports
+import TestUtils
 
 -- external imports
 
 import Control.Exception
-
 import Test.Framework
 import Test.HUnit
 import Test.Framework.Providers.HUnit
@@ -22,38 +22,34 @@ import Test.Framework.Providers.HUnit
 _log :: String
 _log = "test.transport.udp"
 
-address1 :: Address
-address1 = "localhost:2003"
-
-address2 :: Address
-address2 = "localhost:2004"
-
 tests :: [Test.Framework.Test]
 tests = 
   [
     testCase "udp-endpoints+transport" testEndpointTransport,
 
-    testCase "udp-bind-unbind" $ endpointBindUnbind _log newUDPTransport address1 address2,
-    testCase "udp-send-receive" $ endpointSendReceive _log newUDPTransport address1 address2,
-    testCase "udp-double-send-receive" $ endpointDoubleSendReceive _log newUDPTransport address1 address2,
-    testCase "udp-send-receive-reply" $ endpointSendReceiveReply _log newUDPTransport address1 address2,
-    testCase "udp-multiple-send-receive-reply" $ endpointMultipleSendReceiveReply _log newUDPTransport address1 address2,
-    testCase "udp-local-send-receive-reply" $ endpointLocalSendReceiveReply _log newUDPTransport address1 address2,
+    testCase "udp-bind-unbind" $ endpointBindUnbind _log newUDPTransport newUDPAddress,
+    testCase "udp-send-receive" $ endpointSendReceive _log newUDPTransport newUDPAddress,
+    testCase "udp-double-send-receive" $ endpointDoubleSendReceive _log newUDPTransport newUDPAddress,
+    testCase "udp-send-receive-reply" $ endpointSendReceiveReply _log newUDPTransport newUDPAddress,
+    testCase "udp-multiple-send-receive-reply" $ endpointMultipleSendReceiveReply _log newUDPTransport newUDPAddress,
+    testCase "udp-local-send-receive-reply" $ endpointLocalSendReceiveReply _log newUDPTransport newUDPAddress,
     
     testCase "udp6-endpoints+transport" $ whenIPv6 $ testEndpointTransport,
 
-    testCase "udp6-bind-unbind" $ whenIPv6 $ endpointBindUnbind _log newUDPTransport6 address1 address2,
-    testCase "udp6-send-receive" $ whenIPv6 $ endpointSendReceive _log newUDPTransport6 address1 address2,
-    testCase "udp6-double-send-receive" $ whenIPv6 $ endpointDoubleSendReceive _log newUDPTransport6 address1 address2,
-    testCase "udp6-send-receive-reply" $ whenIPv6 $ endpointSendReceiveReply _log newUDPTransport6 address1 address2,
-    testCase "udp6-multiple-send-receive-reply" $ whenIPv6 $ endpointMultipleSendReceiveReply _log newUDPTransport6 address1 address2,
-    testCase "udp6-local-send-receive-reply" $ whenIPv6 $ endpointLocalSendReceiveReply _log newUDPTransport6 address1 address2
+    testCase "udp6-bind-unbind" $ whenIPv6 $ endpointBindUnbind _log newUDPTransport6 newUDPAddress6,
+    testCase "udp6-send-receive" $ whenIPv6 $ endpointSendReceive _log newUDPTransport6 newUDPAddress6,
+    testCase "udp6-double-send-receive" $ whenIPv6 $ endpointDoubleSendReceive _log newUDPTransport6 newUDPAddress6,
+    testCase "udp6-send-receive-reply" $ whenIPv6 $ endpointSendReceiveReply _log newUDPTransport6 newUDPAddress6,
+    testCase "udp6-multiple-send-receive-reply" $ whenIPv6 $ endpointMultipleSendReceiveReply _log newUDPTransport6 newUDPAddress6,
+    testCase "udp6-local-send-receive-reply" $ whenIPv6 $ endpointLocalSendReceiveReply _log newUDPTransport6 newUDPAddress6
   ]
 
 testEndpointTransport :: Assertion
 testEndpointTransport = do
   let name1 = "endpoint1"
       name2 = "endpoint2"
+  address1 <- newUDPAddress
+  address2 <- newUDPAddress
   let resolver = resolverFromList [(name1,address1),
                                (name2,address2)]
   bracket (newUDPTransport resolver)

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -1,0 +1,52 @@
+module TestUtils
+    ( newTCPAddress
+    , newUDPAddress
+    , newTCPAddress6
+    , newUDPAddress6)
+    where
+
+import Control.Exception
+import qualified Network.Socket as NS
+
+newTCPAddress :: IO String
+newTCPAddress = do
+  NS.SockAddrInet (NS.PortNum p) _ <- availablePort NS.AF_INET NS.Stream
+  return $ "localhost:" ++ show p
+
+newUDPAddress :: IO String
+newUDPAddress = do
+  NS.SockAddrInet (NS.PortNum p) _ <- availablePort NS.AF_INET NS.Datagram
+  return $ "localhost:" ++ show p
+
+newTCPAddress6 :: IO String
+newTCPAddress6 = do
+  NS.SockAddrInet6 (NS.PortNum p) _ _ _ <- availablePort NS.AF_INET6 NS.Stream
+  return $ "localhost:" ++ show p
+
+newUDPAddress6 :: IO String
+newUDPAddress6 = do
+  NS.SockAddrInet6 (NS.PortNum p) _ _ _ <- availablePort NS.AF_INET6 NS.Datagram
+  return $ "localhost:" ++ show p
+
+availablePort     :: NS.Family -> NS.SocketType -> IO NS.SockAddr
+availablePort f t = do
+  let hints = NS.defaultHints { NS.addrFamily = f
+                              , NS.addrSocketType = t
+                              , NS.addrFlags = [ NS.AI_PASSIVE ]
+                              , NS.addrProtocol = NS.defaultProtocol }
+  addrs <- NS.getAddrInfo (Just hints) Nothing (Just "0")
+  let a = head addrs
+  bracket
+    (NS.socket (NS.addrFamily a) (NS.addrSocketType a) (NS.addrProtocol a))
+    NS.close
+    (\s -> do
+       NS.bindSocket s (NS.addrAddress a)
+       addr <- NS.getSocketName s
+       if isPrivileged addr
+         then availablePort f t
+         else return addr
+    )
+
+isPrivileged :: NS.SockAddr -> Bool
+isPrivileged (NS.SockAddrInet (NS.PortNum p) _) = p < 1025
+isPrivileged (NS.SockAddrInet6 (NS.PortNum p) _ _ _) = p < 1025


### PR DESCRIPTION
The current tests cannot be run in parallel, because several tests use the same ports (20000 and 20001) for their endpoints:

```
$ cabal test --test-options=-j10
Building courier-0.1.0.15...
Preprocessing library courier-0.1.0.15...
In-place registering courier-0.1.0.15...
Preprocessing test suite 'test-courier' for courier-0.1.0.15...
Running 1 test suites...
Test suite test-courier: RUNNING...
[..]
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20001: bind: resource busy (Address already in use)
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20001: bind: resource busy (Address already in use)
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20001: bind: resource busy (Address already in use)
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20001: bind: resource busy (Address already in use)
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20001: bind: resource busy (Address already in use)
2014-07-05 17:15:29 BST [WARNING] - IPv6 not available
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20002: bind: resource busy (Address already in use)
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20002: bind: resource busy (Address already in use)
2014-07-05 17:15:29 BST [WARNING] - Listen error on port localhost:20002: bind: resource busy (Address already in use)
tcp-bind-unbind: [OK]
[..]
2014-07-05 17:15:30 BST [ERROR] - Encountered error running test: HUnitFailure "Received message not same as sent\nexpected: Right \"hi!\"\n but got: Right \"hello\""
2014-07-05 17:15:31 BST [ERROR] - Encountered error running test: HUnitFailure "No message received"
2014-07-05 17:15:31 BST [ERROR] - Encountered error running test: HUnitFailure "No message received"
2014-07-05 17:15:31 BST [ERROR] - Encountered error running test: HUnitFailure "No message received"
2014-07-05 17:15:31 BST [ERROR] - Encountered error running test: HUnitFailure "No message received"
2014-07-05 17:15:31 BST [ERROR] - Encountered error running test: HUnitFailure "No message received"
2014-07-05 17:15:31 BST [ERROR] - Encountered error running test: HUnitFailure "No message received"
[..]
         Test Cases   Total       
 Passed  41           41          
 Failed  7            7           
 Total   48           48          
Test suite test-courier: FAIL
Test suite logged to: dist/test/courier-0.1.0.15-test-courier.log
0 of 1 test suites (0 of 1 test cases) passed.
$
```

The code in this pull request uses arbitrary port numbers, so test may be run now in parallel --- and faster!

With one single thread:

```
$ time cabal test
Building courier-0.1.0.15...
Preprocessing library courier-0.1.0.15...
In-place registering courier-0.1.0.15...
Preprocessing test suite 'test-courier' for courier-0.1.0.15...
Running 1 test suites...
Test suite test-courier: RUNNING...
Test suite test-courier: PASS
Test suite logged to: dist/test/courier-0.1.0.15-test-courier.log
1 of 1 test suites (1 of 1 test cases) passed.

real    0m12.389s
user    0m1.249s
sys     0m0.108s
$
```

With then threads, on my 8-core Linux system:

```
$ time cabal test --test-options=-j10
Building courier-0.1.0.15...
Preprocessing library courier-0.1.0.15...
In-place registering courier-0.1.0.15...
Preprocessing test suite 'test-courier' for courier-0.1.0.15...
Running 1 test suites...
Test suite test-courier: RUNNING...
Test suite test-courier: PASS
Test suite logged to: dist/test/courier-0.1.0.15-test-courier.log
1 of 1 test suites (1 of 1 test cases) passed.

real    0m2.795s
user    0m1.241s
sys     0m0.103s
$
```
