### PR TITLE
Export Resolver constructor

### DIFF
--- a/src/Network/Transport.hs
+++ b/src/Network/Transport.hs
@@ -34,7 +34,7 @@ module Network.Transport (
   Envelope(..),
   Message,
   Name,
-  Resolver,
+  Resolver(..),
   resolve,
   resolverFromList,
   Scheme,


### PR DESCRIPTION
I propose that the Resolver constructor is exported, or that a separate constructor function is exposed.

As it is right now it is impossible to create a custom Resolver, with a function of type `Name -> IO (Maybe Address)`.  To create a custom
dynamic resolver, the Resolver constructor needs to be exported:

``` haskell
nodes <- newMVar []
let resolver = Resolver (\name -> readMVar nodes >>= return . lookup name)
```

would create a dynamic resolver that could be altered at runtime.
